### PR TITLE
Recommended declaration of server "Content-Type".

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ app.configure(function(){
 i18n.registerAppHelper(app);
 	
 app.get('/', function(req, res) {
+	res.header("Content-Type", "text/html; charset=utf-8");
 	res.render('index', { title: 'Localization with Express, Jade and i18next-node' });
 });
 


### PR DESCRIPTION
Please see [this issue](http://stackoverflow.com/questions/18277858/how-to-get-i18next-node-to-display-umlauts-the-right-way) on Stack Overflow which was partly caused by lack of "Content-Type" header field. Having this might prevent future issues for people starting with i18n on Express.
